### PR TITLE
Crawl Session: adds sitemap support

### DIFF
--- a/src/RavenTools/SiteAuditorSdk/Resources/CrawlSession.php
+++ b/src/RavenTools/SiteAuditorSdk/Resources/CrawlSession.php
@@ -7,6 +7,7 @@ use RavenTools\SiteAuditorSdk\ResourceCollection;
 class CrawlSession extends Common {
 
 	protected $get_endpoint = "crawl_sessions/{id}";
+	protected $sitemap_endpoint = "crawl_sessions/{id}/sitemap";
 	protected $delete_endpoint = "crawl_sessions/{id}";
 	protected $previous_endpoint = "crawl_sessions/{id}/previous";
 	protected $history_endpoint = "crawl_sessions/history/{site_id}";
@@ -49,5 +50,20 @@ class CrawlSession extends Common {
 			'response' => $response,
 			'resource_type' => static::class
 		]);
+	}
+
+	public function sitemap($resource_id) {
+		$params = [
+			'id' => $resource_id,
+		];
+
+		$uri = $this->substitute($this->sitemap_endpoint, $params);
+		$response = $this->client->request('GET', $uri);
+
+		if($response === false) {
+			return false;
+		}
+
+		return $response->getBody();
 	}
 }

--- a/test.php
+++ b/test.php
@@ -152,6 +152,19 @@ case "getcrawlhistory":
 
 	break;
 
+case "getcrawlsitemap":
+	if(!isset($argv[2])) {
+		echo "id argument required\n";
+		exit(1);
+	}
+	$id = $argv[2];
+
+	$response = $client->factory(CrawlSession::class)->sitemap($id);
+
+	echo $response;
+
+	break;
+
 case "deletesession":
 	if(!isset($argv[2])) {
 		echo "id argument required\n";


### PR DESCRIPTION
Platform has an option to download a simple sitemap xml file which includes all of the page urls that were crawled.  This adds client support for the api endpoint.